### PR TITLE
Refactor CI to run build on pull_request and deploy on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-
     timeout-minutes: 60
 
     steps:
@@ -250,6 +250,7 @@ jobs:
         run: bundle exec rails assets:precompile
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     env:


### PR DESCRIPTION
CI/CDのトリガー設定を修正した
- mainブランチへのプルリクエスト時：build ジョブのみ
- mainブランチへのプッシュ時：deploy ジョブのみ