### PR TITLE
Set config.assets.prefix to '/assets/builds' for correct asset loadin…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
   config.assets.precompile += %w( application.js application.css )
+  config.assets.prefix = "/assets/builds"
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
config/environments/production.rb に config.assets.prefix = "/assets/builds" を追記した