### PR TITLE
Rename .render.yaml to render.yaml for proper recognition by Render.com

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,5 +5,5 @@ services:
     plan: starter
     dockerfilePath: ./Dockerfile.production
     dockerComposeYamlPath: ./docker-compose.production.yml
-    buildCommand: ./bin/render-build.sh
+    preDeployCommand: ./bin/render-build.sh
     startCommand: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
.render.yaml を render.yaml に修正した