### PR TITLE
chore(deps): update erb to 6.0.4 to fix CVE-2026-41316

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (6.0.3)
+    erb (6.0.4)
     erubi (1.13.1)
     esbuild-rails (0.1.4)
       rails (>= 6.0.0)


### PR DESCRIPTION
chore(deps): update erb to 6.0.4 to fix CVE-2026-41316